### PR TITLE
refactor(k3s): add sha256sum endpoint for k3s script install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,9 @@ jobs:
     - env: INSTANCE=redhat-fedora-31-master-py3
     - env: INSTANCE=default-opensuse-leap-151-master-py3
     - env: INSTANCE=default-amazonlinux-2-master-py3
+    # k3s script install tests
+    - env: INSTANCE=script-ubuntu-1804-master-py3
+    # - env: INSTANCE=script-amazonlinux-2-master-py3
     # - env: INSTANCE=default-debian-10-3000-2-py3
     # - env: INSTANCE=default-debian-9-3000-2-py3
     # - env: INSTANCE=default-ubuntu-1804-3000-2-py3

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -300,3 +300,20 @@ suites:
     verifier:
       inspec_tests:
         - path: test/integration/arch
+  - name: script
+    provisioner:
+      state_top:
+        base:
+          '*':
+            # kubernetes.clean
+            - kubernetes.k3s
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - kubernetes
+      pillars_from_files:
+        kubernetes.sls: test/salt/pillar/script.sls
+    verifier:
+      inspec_tests:
+        - path: test/integration/script

--- a/kubernetes/defaults.yaml
+++ b/kubernetes/defaults.yaml
@@ -417,7 +417,7 @@ kubernetes:
       binary:
         source_hash: '5ce3e0cea46501c652653ee59a40441ebd84d86eb7bf0a9845c9831f0d73bf20'
       script:
-        source_hash: 'b2856cee3432cf0148513b644b5369db8fa8b039793959f410aa7dfdb496b2b9'  # hash changes frequently
+        source_hash:
         killall: /usr/local/bin/k3s-killall.sh
         uninstall: /usr/local/bin/k3s-uninstall.sh
         env:

--- a/kubernetes/map.jinja
+++ b/kubernetes/map.jinja
@@ -95,7 +95,7 @@
                 {%- if 'source_hash' in p.script and p.script.source_hash %}
                     {%- do p.script.update({'source_hash': p.script.source_hash}) %}
                 {%- else %}
-                    {%- do p.script.update({'source_hash': url ~ '.sha256'}) %}
+                    {%- do p.script.update({'source_hash': '%s/%s'|format(p.uri_s, 'sha256') }) %}
                 {%- endif %}
             {%- endif %}
         {%- endif %}

--- a/test/integration/script/README.md
+++ b/test/integration/script/README.md
@@ -1,0 +1,50 @@
+# InSpec Profile: `default`
+
+This shows the implementation of the `default` InSpec [profile](https://github.com/inspec/inspec/blob/master/docs/profiles.md).
+
+## Verify a profile
+
+InSpec ships with built-in features to verify a profile structure.
+
+```bash
+$ inspec check default
+Summary
+-------
+Location: default
+Profile: profile
+Controls: 4
+Timestamp: 2019-06-24T23:09:01+00:00
+Valid: true
+
+Errors
+------
+
+Warnings
+--------
+```
+
+## Execute a profile
+
+To run all **supported** controls on a local machine use `inspec exec /path/to/profile`.
+
+```bash
+$ inspec exec default
+..
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+8 examples, 0 failures
+```
+
+## Execute a specific control from a profile
+
+To run one control from the profile use `inspec exec /path/to/profile --controls name`.
+
+```bash
+$ inspec exec default --controls package
+.
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+1 examples, 0 failures
+```
+
+See an [example control here](https://github.com/inspec/inspec/blob/master/examples/profile/controls/example.rb).

--- a/test/integration/script/controls/default_spec.rb
+++ b/test/integration/script/controls/default_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+title 'kubernetes archives profile'
+
+control 'kubernetes archive' do
+  impact 1.0
+  title 'should be installed'
+
+  describe file('/etc/systemd/system/k3s.service') do
+    it { should exist }
+    it { should_not be_directory }
+    its('type') { should eq :file }
+  end
+  describe file('/usr/local/bin/k3s-killall.sh') do
+    it { should exist }
+    it { should_not be_directory }
+    its('type') { should eq :file }
+  end
+  describe file('/etc/rancher/k3s/k3s.yaml') do
+    it { should exist }
+    it { should_not be_directory }
+    its('type') { should eq :file }
+  end
+  describe file('/usr/local/bin/k3s') do
+    it { should be_file }
+    it { should_not be_directory }
+  end
+  describe file('/etc/rancher/k3s') do
+    it { should be_directory }
+    it { should_not be_file }
+  end
+  describe file('/var/lib/rancher/k3s/server/cred/admin.kubeconfig') do
+    it { should exist }
+    it { should_not be_directory }
+    its('type') { should eq :file }
+  end
+  describe file('/var/lib/rancher/k3s/agent/k3scontroller.kubeconfig') do
+    it { should exist }
+    it { should_not be_directory }
+    its('type') { should eq :file }
+  end
+  describe file('/var/lib/rancher/k3s/server/node-token') do
+    it { should be_symlink }
+    it { should be_file }
+    it { should_not be_directory }
+  end
+end

--- a/test/integration/script/inspec.yml
+++ b/test/integration/script/inspec.yml
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+name: script
+title: kubernetes formula
+maintainer: SaltStack Formulas
+license: Apache-2.0
+summary: Verify that the kubernetes formula is setup and configured correctly
+supports:
+  - platform-name: debian
+  - platform-name: ubuntu
+  - platform-name: centos
+  - platform-name: fedora
+  - platform-name: opensuse
+  - platform-name: suse
+  - platform-name: freebsd
+  - platform-name: amazon
+  - platform-name: arch

--- a/test/salt/pillar/script.sls
+++ b/test/salt/pillar/script.sls
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# This formula works with no-pillars but here are some example configurations.
+
+kubernetes:
+  supported:
+    - client
+    - k3s
+  operator:
+    wanted:
+      - sdk
+# test script installation
+  k3s:
+    pkg:
+      use_upstream: script
+
+  linux:
+    altpriority: 1000


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [x] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

https://github.com/saltstack-formulas/kubernetes-formula/issues/23
https://github.com/rancher/k3s/issues/2378 

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This change uses the `https://get.k3s.io/sha256` endpoint to validate the hash for the current k3s install script

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

N/A - no pillar changes required, if no `source_hash` set, then it will use the URL

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->
```
[INFO    ] Running state [/tmp/kubernetes-tmp//k3s-bootstrap.sh] at time 21:56:43.093716
[INFO    ] Executing state file.managed for [/tmp/kubernetes-tmp//k3s-bootstrap.sh]
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'saltmaster', u'tcp://192.168.50.4:4506', u'aes')
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'saltmaster', u'tcp://192.168.50.4:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://192.168.50.4:4506
[DEBUG   ] Trying to connect to: tcp://192.168.50.4:4506
[DEBUG   ] Requesting URL https://get.k3s.io/sha256 using GET method
[DEBUG   ] Using backend: tornado
[DEBUG   ] file.extract_hash: Extracting any supported hash for file matching either of the following: /tmp/kubernetes-tmp//k3s-bootstrap.sh, https://get.k3s.io/vv1.18.10+k3s1/k3s-linux-
[DEBUG   ] file.extract_hash: Line 'd5bdb06c385673e932de17c0cef3c8f5c48bc2143ad06fbaa58ccce4d7766811' contains sha256 hash 'd5bdb06c385673e932de17c0cef3c8f5c48bc2143ad06fbaa58ccce4d7766811', but line did not meet the search criteria
[DEBUG   ] file.extract_hash: Returning the partially identified sha256 hash 'd5bdb06c385673e932de17c0cef3c8f5c48bc2143ad06fbaa58ccce4d7766811'
[DEBUG   ] Requesting URL https://get.k3s.io/vv1.18.10+k3s1/k3s-linux- using GET method
[DEBUG   ] Using backend: tornado
[INFO    ] File changed:
New file
[INFO    ] Completed state [/tmp/kubernetes-tmp//k3s-bootstrap.sh] at time 21:56:43.545494 (duration_in_ms=451.777)
```

Note: All Kitchen tests still pass, as only the binary install is tested. As per this comment: https://github.com/saltstack-formulas/kubernetes-formula/issues/23#issuecomment-732508454 I'm not sure exactly how to split the test for script vs binary, especially since even the test defaults to binary unless `defaults.yaml` is changed to script. If that change was made, we could update the tests to verify the changed paths for script install.

I ran Kitchen tests on all the configured builds, and spot checked 10 or so, all of them had correctly installed k3s, and k3s was running and usable.

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

Let me know if there is anything else I could/should do in this PR to make it more useful
