### PR TITLE
feat(cri-resmgr): basic cri-resmgr-support / remove some jinja

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -5,14 +5,15 @@ kubernetes-formula
 
 Extensible formula to manage kubernetes on MacOS, Windows, and GNU/Linux. Currently supports:
 
-* `server`  (https://kubernetes.io) [Linux OS]
-* `node`    (https://kubernetes.io) [all OS]
+* `server` (https://kubernetes.io) [Linux OS]
+* `node` (https://kubernetes.io) [all OS]
 * `client`  (https://kubernetes.io, aliases) [all OS]
 * `operator` (sdk, etc)
 * `operators` (https://operatorhub.io)  [all OS]
 * `devtools` (extensive collection of tools, kubectx, kubens, cue, attr2rbac, dive, stern, etc)  [all OS]
 * `devlibs`  (kubernetes clients, source software)  [all OS]
 * `sigs`  (https://github.com/kubernetes-sigs, special interest groups)  [all OS]
+* `crimgr` (cri-resource-manager, etc) [linux]
 
 
 The default `kubernetes.sigs` state includes the following:
@@ -64,6 +65,10 @@ The default `kubernetes.devlibs` state includes [all OS]:
 * `Javascript client library for kubernetes` (https://github.com/kubernetes-client/javascript)
 * `Python kubernetes-operator library` (https://github.com/zalando-incubator/kopf)
 * `Simple kubernetes Go client` (https://github.com/ericchiang/k8s)
+
+The default `kubernetes.crimgr` state includes (linux):
+
+* `cri` CRI Resource Manager (https://github.com/intel/cri-resource-manager)
 
 
 |img_travis| |img_sr|
@@ -231,6 +236,18 @@ This state installs selected kubernetes developer libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This state uninstalls selected kubernetes developer libraries (i.e. kubernetes client libraries, kopf, etc).
+
+``kubernetes.crimgr``
+^^^^^^^^^^^^^^^^^^^^^
+
+This state installs kubernetes cri-resource-manager
+
+* https://github.com/intel/cri-resource-manager
+
+``kubernetes.crimgr.clean``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This state uninstalls kubernetes cri-resource-manager
 
 
 Main Sub-states

--- a/kubernetes/clean.sls
+++ b/kubernetes/clean.sls
@@ -11,3 +11,4 @@ include:
   - .devtools.clean
   - .devlibs.clean
   - .sigs.clean
+  - .managers.clean

--- a/kubernetes/clean.sls
+++ b/kubernetes/clean.sls
@@ -11,4 +11,4 @@ include:
   - .devtools.clean
   - .devlibs.clean
   - .sigs.clean
-  - .managers.clean
+  - .crimgr.clean

--- a/kubernetes/client/aliases/clean.sls
+++ b/kubernetes/client/aliases/clean.sls
@@ -3,9 +3,8 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
-{{ formula }}-client-aliases-clean:
+kubernetes-client-aliases-clean:
   file.absent:
     - names:
       - {{ d.client.aliases_file }}

--- a/kubernetes/client/aliases/install.sls
+++ b/kubernetes/client/aliases/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if grains.os != 'Windows' %}
     {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
@@ -14,7 +13,7 @@
 include:
   - {{ sls_archive_install if d.client.pkg.use_upstream == 'archive' else sls_binary_install if d.client.pkg.use_upstream == 'binary' else sls_package_install }}   # noqa 204
 
-{{ formula }}-client-aliases-file-managed-environ_file:
+kubernetes-client-aliases-file-managed-environ_file:
   file.managed:
     - name: {{ d.client.aliases_file }}
     - source: {{ files_switch(['aliases.sh.jinja'],

--- a/kubernetes/client/alternatives/clean.sls
+++ b/kubernetes/client/alternatives/clean.sls
@@ -3,12 +3,11 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- for cmd in d.client.pkg.commands|unique %}
 
-{{ formula }}-client-alternatives-remove-bin-{{ cmd }}:
+kubernetes-client-alternatives-remove-bin-{{ cmd }}:
   alternatives.remove:
     - name: link-k8s-client-{{ cmd }}
     - path: {{ d.client.pkg.path }}/bin/{{ cmd }}

--- a/kubernetes/client/alternatives/install.sls
+++ b/kubernetes/client/alternatives/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- set sls_archive_install = tplroot ~ '.client.archive.install' %}
@@ -15,7 +14,7 @@ include:
 
         {%- for cmd in d.client.pkg.commands|unique %}
 
-{{ formula }}-client-alternatives-install-bin-{{ cmd }}:
+kubernetes-client-alternatives-install-bin-{{ cmd }}:
             {%- if grains.os_family not in ('Suse', 'Arch') %}
   alternatives.install:
     - name: link-k8s-client-{{ cmd }}
@@ -36,9 +35,9 @@ include:
     - require:
       - sls: {{ sls_archive_install if d.client.pkg.use_upstream == 'archive' else sls_binary_install }}
     - require_in:
-      - alternatives: {{ formula }}-client-alternatives-set-bin-{{ cmd }}
+      - alternatives: kubernetes-client-alternatives-set-bin-{{ cmd }}
 
-{{ formula }}-client-alternatives-set-bin-{{ cmd }}:
+kubernetes-client-alternatives-set-bin-{{ cmd }}:
   alternatives.set:
     - unless:
       - {{ grains.os_family in ('Suse', 'Arch') }} || false

--- a/kubernetes/client/archive/clean.sls
+++ b/kubernetes/client/archive/clean.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- set sls_alternatives_clean = tplroot ~ '.client.alternatives.clean' %}
 include:
   - {{ sls_alternatives_clean }}
 
-{{ formula }}-client-archive-absent:
+kubernetes-client-archive-absent:
   file.absent:
     - names:
       - {{ d.dir.tmp }}/client*

--- a/kubernetes/client/archive/install.sls
+++ b/kubernetes/client/archive/install.sls
@@ -3,25 +3,24 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if grains.kernel|lower in ('linux', 'darwin', 'windows') %}
         {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
         {%- if d.client.pkg.use_upstream == 'archive' and 'pkg' in d.client and 'archive' in d.client['pkg'] %}
 
-{{ formula }}-client-archive-install:
+kubernetes-client-archive-install:
             {%- if grains.os|lower != 'windows' %}
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     - require_in:
-      - file: {{ formula }}-client-archive-install
+      - file: kubernetes-client-archive-install
             {%- endif %}
   file.directory:
     - name: {{ d.client.pkg.path }}
     - makedirs: True
     - clean: {{ d.clean }}
     - require_in:
-      - archive: {{ formula }}-client-archive-install
+      - archive: kubernetes-client-archive-install
             {%- if grains.os|lower != 'windows' %}
     - mode: 755
     - user: {{ d.identity.rootuser }}
@@ -38,7 +37,7 @@
     - trim_output: true
     - force: true
     - require:
-      - file: {{ formula }}-client-archive-install
+      - file: kubernetes-client-archive-install
             {%- if grains.os|lower != 'windows' %}
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
@@ -49,20 +48,20 @@
                 {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                     {%- for cmd in d.client.pkg.commands|unique %}
 
-{{ formula }}-client-archive-install-symlink-{{ cmd }}:
+kubernetes-client-archive-install-symlink-{{ cmd }}:
   file.symlink:
     - name: /usr/local/bin/{{ cmd }}
     - target: {{ d.client.pkg.path }}/bin/{{ cmd }}
     - force: True
     - require:
-      - archive: {{ formula }}-client-archive-install
+      - archive: kubernetes-client-archive-install
 
                     {%- endfor %}
                 {%- endif %}
             {%- endif %}
             {%- if grains.os|lower == 'windows' %}
 
-{{ formula }}-client-archive-install-bashrc:
+kubernetes-client-archive-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -71,13 +70,13 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-client-archive-install-bashrc
+      - file: kubernetes-client-archive-install-bashrc
 
             {%- endif %}
         {%- endif %}
     {%- else %}
 
-{{ formula }}-client-archive-install-other:
+kubernetes-client-archive-install-other:
   test.show_notification:
     - text: |
         The client archive is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}

--- a/kubernetes/client/binary/clean.sls
+++ b/kubernetes/client/binary/clean.sls
@@ -3,9 +3,8 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
-{{ formula }}-client-binary-clean:
+kubernetes-client-binary-clean:
   file.absent:
     - names:
       - /usr/local/bin/kubectl

--- a/kubernetes/client/binary/install.sls
+++ b/kubernetes/client/binary/install.sls
@@ -3,16 +3,15 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.client.pkg.use_upstream == 'binary' %}
 
-{{ formula }}-client-binary-install:
+kubernetes-client-binary-install:
         {%- if grains.os|lower != 'windows' %}
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     - require_in:
-      - file: {{ formula }}-client-binary-install
+      - file: kubernetes-client-binary-install
         {%- endif %}
   file.managed:
     - name: {{ d.client.pkg.path }}
@@ -29,18 +28,18 @@
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
 
-{{ formula }}-client-binary-install-symlink:
+kubernetes-client-binary-install-symlink:
   file.symlink:
     - name: /usr/local/bin/kubectl
     - target: {{ d.client.pkg.path }}/bin/kubectl
     - force: True
     - require:
-      - cmd: {{ formula }}-client-binary-install
+      - cmd: kubernetes-client-binary-install
     - unless: {{ d.linux.altpriority|int > 0 }} || false
 
         {%- elif grains.os|lower == 'windows' %}
 
-{{ formula }}-client-binary-install-bashrc:
+kubernetes-client-binary-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -49,7 +48,7 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-client-binary-install-bashrc
+      - file: kubernetes-client-binary-install-bashrc
 
         {%- endif %}
     {%- endif %}

--- a/kubernetes/client/package/clean.sls
+++ b/kubernetes/client/package/clean.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.client.pkg.use_upstream in ('package', 'repo') %}
         {%- if grains.kernel|lower in ('linux',) %}
@@ -13,18 +12,18 @@ include:
   - .package.repo.clean
             {%- endif %}
 
-{{ formula }}-client-package-clean-pkg:
+kubernetes-client-package-clean-pkg:
   pkg.removed:
     - name: kubectl
     - reload_modules: true
             {%- if d.client.pkg.use_upstream == 'repo' %}
     - require:
-      - pkgrepo: {{ formula }}-package-repo-absent
+      - pkgrepo: kubernetes-package-repo-absent
             {%- endif %}
 
         {%- elif grains.os_family == 'MacOS' %}
 
-{{ formula }}-client-package-clean-brew:
+kubernetes-client-package-clean-brew:
   cmd.run:
     - name:  /usr/local/bin/brew uninstall kubectl
     - runas: {{ d.identity.rootuser }}
@@ -34,7 +33,7 @@ include:
 
         {%- elif grains.os_family == 'Windows' %}
 
-{{ formula }}-client-package-clean-choco:
+kubernetes-client-package-clean-choco:
   chocolatey.uninstalled:
     - name: {{ d.client.pkg.name }}
 

--- a/kubernetes/client/package/install.sls
+++ b/kubernetes/client/package/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.client.pkg.use_upstream in ('package', 'repo') %}
 
@@ -13,32 +12,32 @@ include:
   - .package.repo.install
             {%- endif %}
 
-{{ formula }}-client-package-install-deps:
+kubernetes-client-package-install-deps:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     - require_in:
-      - pkg: {{ formula }}-client-package-install-pkg
+      - pkg: kubernetes-client-package-install-pkg
 
-{{ formula }}-client-package-install-pkg:
+kubernetes-client-package-install-pkg:
   pkg.installed:
     - name: {{ d.client.pkg.name }}
     - runas: {{ d.identity.rootuser }}
     - reload_modules: true
             {%- if d.client.pkg.use_upstream == 'repo' %}
     - require:
-      - pkgrepo: {{ formula }}-package-repo-managed
+      - pkgrepo: kubernetes-package-repo-managed
             {%- endif %}
 
         {%- elif grains.kernel|lower in ('MacOS',) %}
 
-{{ formula }}-client-package-install-brew:
+kubernetes-client-package-install-brew:
   cmd.run:
     - name: /usr/local/bin/brew install {{ d.client.pkg.name }}
     - runas: {{ d.identity.rootuser }}
     - onlyif:
       - test -x /usr/local/bin/brew
 
-{{ formula }}-client-package-reinstall-brew:
+kubernetes-client-package-reinstall-brew:
   cmd.run:
     - name: /usr/local/bin/brew reinstall kubectl
     - runas: {{ d.identity.rootuser }}
@@ -46,7 +45,7 @@ include:
 
         {%- elif grains.kernel|lower in ('windows',) %}
 
-{{ formula }}-client-package-install-choco:
+kubernetes-client-package-install-choco:
   chocolatey.installed:
     - name: {{ d.client.pkg.name }}
     - force: True

--- a/kubernetes/crimgr/alternatives/clean.sls
+++ b/kubernetes/crimgr/alternatives/clean.sls
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import data as d with context %}
+
+    {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
+        {%- if 'wanted' in d.crimgr and d.crimgr.wanted and d.crimgr['pkg'] %}
+            {%- for cmd in d.crimgr['pkg']['commands']|unique %}
+
+kubernetes-cri-resource-manager-alternatives-clean-{{ cmd }}:
+  alternatives.remove:
+    - name: link-k8s-cri-resource-manager-{{ cmd }}
+    - path: {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }}
+    - onlyif:
+      - update-alternatives --list |grep ^link-k8s-cri-resource-manager-{{ cmd }}
+
+            {%- endfor %}
+        {%- endif %}
+    {%- endif %}

--- a/kubernetes/crimgr/alternatives/init.sls
+++ b/kubernetes/crimgr/alternatives/init.sls
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - .install

--- a/kubernetes/crimgr/alternatives/install.sls
+++ b/kubernetes/crimgr/alternatives/install.sls
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import data as d with context %}
+
+    {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
+        {%- set sls_archive_install = tplroot ~ '.crimgr.archive.install' %}
+
+include:
+  - {{ sls_archive_install }}
+
+        {%- if 'wanted' in d.crimgr and d.crimgr.wanted and 'pkg' in d.crimgr and d.crimgr['pkg'] %}
+            {%- for cmd in d.crimgr['pkg']['commands']|unique %}
+
+kubernetes-cri-resource-manager-alternatives-install-bin-{{ cmd }}:
+                {%- if grains.os_family in ('Suse', 'Arch') %}
+  alternatives.install:
+    - name: link-k8s-cri-resource-manager-{{ cmd }}
+    - link: /usr/local/bin/{{ cmd }}
+    - order: 10
+    - path: {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }}
+    - priority: {{ d.linux.altpriority }}
+                {%- else %}
+  cmd.run:
+    - name: update-alternatives --install /usr/local/bin/{{ cmd }} link-k8s-cri-resource-manager-{{ cmd }} {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }} {{ d.linux.altpriority }} # noqa 204
+                {%- endif %}
+
+    - onlyif:
+      - test -f {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }}
+    - unless: update-alternatives --list |grep ^link-k8s-cri-resource-manager-{{ cmd }} || false
+    - require:
+      - sls: {{ sls_archive_install }}
+    - require_in:
+      - alternatives: kubernetes-cri-resource-manager-alternatives-set-bin-{{ cmd }}
+
+kubernetes-cri-resource-manager-alternatives-set-bin-{{ cmd }}:
+  alternatives.set:
+    - unless: {{ grains.os_family in ('Suse', 'Arch') }} || false
+    - name: link-k8s-cri-resource-manager-{{ cmd }}
+    - path: {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }}
+    - onlyif:
+      - test -f {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }}
+
+            {%- endfor %}
+        {%- endif %}
+    {%- endif %}

--- a/kubernetes/crimgr/archive/clean.sls
+++ b/kubernetes/crimgr/archive/clean.sls
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import data as d with context %}
+
+    {%- if grains.kernel|lower == 'linux' %}
+        {%- if 'pkg' in d.crimgr and d.crimgr.pkg %}
+
+kubernetes-cri-resource-manager-archive-clean:
+  file.absent:
+    - names:
+      - {{ d.crimgr.pkg['path'] }}
+      - /etc/systemd/system/cri-resource-manager.service
+      - /etc/cri-resmgr
+      - /etc/default/cri-resource-manager
+            {%- for cmd in d.crimgr['pkg']['commands']|unique %}
+      - /usr/local/bin/{{ cmd }}
+            {%- endfor %}
+
+        {% endif %}
+    {%- else %}
+
+kubernetes-cri-resource-manager-archive-clean-other:
+  test.show_notification:
+    - text: |
+        The cri-resource-manager archive is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}
+
+    {%- endif %}

--- a/kubernetes/crimgr/archive/init.sls
+++ b/kubernetes/crimgr/archive/init.sls
@@ -1,0 +1,5 @@
+#.-*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - .install

--- a/kubernetes/crimgr/archive/install.sls
+++ b/kubernetes/crimgr/archive/install.sls
@@ -1,0 +1,59 @@
+#  -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import data as d with context %}
+{%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
+
+    {%- if grains.kernel|lower == 'linux' %}
+        {%- if d.crimgr.pkg and d.crimgr.pkg['use_upstream'] == 'archive' and 'archive' in d.crimgr.pkg %}
+
+kubernetes-cri-resource-manager-archive-install:
+  file.directory:
+    - name: {{ d.crimgr.pkg['path'] }}
+    - makedirs: True
+    - clean: {{ d.clean }}
+    - require_in:
+      - archive: kubernetes-cri-resource-manager-archive-install
+    - mode: 755
+    - user: {{ d.identity.rootuser }}
+    - group: {{ d.identity.rootgroup }}
+    - recurse:
+      - user
+      - group
+      - mode
+  archive.extracted:
+    {{- format_kwargs(d.crimgr.pkg['archive']) }}
+    - retry: {{ d.retry_option }}
+    - enforce_toplevel: false
+    - trim_output: true
+    - user: {{ d.identity.rootuser }}
+    - group: {{ d.identity.rootgroup }}
+    - recurse:
+      - user
+      - group
+
+            {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
+                {%- for cmd in d.crimgr.pkg['commands']|unique %}
+
+kubernetes-cri-resource-manager-archive-install-symlink-{{ cmd }}:
+  file.symlink:
+    - name: /usr/local/bin/{{ cmd }}
+    - target:  {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }}
+    - force: True
+    - onlyif:
+      - test -f {{ d.crimgr.pkg['path'] }}/bin/{{ cmd }}
+    - require:
+      - archive: kubernetes-cri-resource-manager-archive-install
+
+                {%- endfor %}
+            {%- endif %}
+        {%- endif %}
+    {%- else %}
+
+kubernetes-cri-resource-manager-archive-install-other:
+  test.show_notification:
+    - text: |
+        The cri-resource-manager archive is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}
+
+    {%- endif %}

--- a/kubernetes/crimgr/clean.sls
+++ b/kubernetes/crimgr/clean.sls
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - .archive.clean
+  - .alternatives.clean

--- a/kubernetes/crimgr/config/clean.sls
+++ b/kubernetes/crimgr/config/clean.sls
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import data as d with context %}
+{%- set sls_archive_clean = tplroot ~ '.crimgr.archive.clean' %}
+
+include:
+  - {{ sls_archive_clean }}
+
+kubernetes-crimgr-config-clean:
+  file.absent:
+    - names:
+      - {{ d.crimgr.config_file }}
+      - {{ d.crimgr.environ_file }}
+    - require:
+      - sls: {{ sls_archive_clean }}

--- a/kubernetes/crimgr/config/environ.sls
+++ b/kubernetes/crimgr/config/environ.sls
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import data as d with context %}
+
+    {%- if grains.kernel|lower == 'linux' and 'environ' in d.crimgr and d.crimgr.environ %}
+        {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
+        {%- set sls_archive_install = tplroot ~ '.crimgr.archive.install' %}
+
+include:
+  - {{ sls_archive_install }}
+
+kubernetes-crimgr-config-file-managed-environ_file:
+  file.managed:
+    - name: {{ d.crimgr.environ_file }}
+    - source: {{ files_switch(['environ.sh.jinja'],
+                              lookup='k8s-crimgr-config-file-managed-environ_file'
+                 )
+              }}
+    - makedirs: True
+              {%- if grains.os != 'Windows' %}
+    - mode: '0640'
+    - user: {{ d.identity.rootuser }}
+    - group: {{ d.identity.rootgroup }}
+              {%- endif %}
+    - template: jinja
+    - context:
+      environ: {{ d.crimgr.environ|json }}
+    - require:
+      - sls: {{ sls_archive_install }}
+
+    {%- endif %}

--- a/kubernetes/crimgr/config/file.sls
+++ b/kubernetes/crimgr/config/file.sls
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import data as d with context %}
+
+    {%- if grains.kernel|lower == 'linux' and 'config' in d.crimgr and d.crimgr.config %}
+        {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
+        {%- set sls_archive_install = tplroot ~ '.crimgr.archive.install' %}
+
+include:
+  - {{ sls_archive_install }}
+
+kubernetes-crimgr-config-file-install-file-managed:
+  file.managed:
+    - name: {{ d.crimgr.config_file }}
+    - source: {{ files_switch(['config.yml.jinja'],
+                              lookup='k8s-crimgr-config-file-install-file-managed'
+                 )
+              }}
+    - makedirs: True
+              {%- if grains.os != 'Windows' %}
+    - mode: 644
+    - user: {{ d.identity.rootuser }}
+    - group: {{ d.identity.rootgroup }}
+              {%- endif %}
+    - template: jinja
+    - context:
+      config: {{ d.crimgr.config|json }}
+    - require:
+      - sls: {{ sls_archive_install }}
+
+    {%- endif %}

--- a/kubernetes/crimgr/config/init.sls
+++ b/kubernetes/crimgr/config/init.sls
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - .file
+  - .environ

--- a/kubernetes/crimgr/init.sls
+++ b/kubernetes/crimgr/init.sls
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - .archive
+  - .alternatives

--- a/kubernetes/defaults.yaml
+++ b/kubernetes/defaults.yaml
@@ -16,6 +16,7 @@ kubernetes:
     - devlibs
     - devtools
     - sigs
+    - crimgr
   sigs:
     wanted:
       - kind
@@ -432,6 +433,23 @@ kubernetes:
       uri_a: 'https://dl.k8s.io'
       archive:
         source_hash: '3e6c90561dd1c27fa1dff6953c503251c36001f7e0f8eff3ec918c74ae2d9aa25917d8ac87d5b4224b8229f620b1830442e6dce3b2a497043f8497eee3705696'  # noqa 204
+        options: '--strip-components=2'
+      suffix: tar.gz
+
+  crimgr:
+    version: '0.4.1'
+    config_file: /etc/cri-resmgr/fallback.cfg
+    config: {}
+    environ: {}
+    environ_file: /etc/default/cri-resource-manager
+    service: {}
+    pkg:
+      commands:
+        - cri-resmgr
+      use_upstream: archive
+      uri_a: 'https://github.com/intel/cri-resource-manager/releases/download'
+      archive:
+        source_hash: '8f1fd0b828ff5e3ba7905e292e4202f12f7caf422a0a65c25364bf578c8f81b1'
         options: '--strip-components=2'
       suffix: tar.gz
 

--- a/kubernetes/devlibs/archive/clean.sls
+++ b/kubernetes/devlibs/archive/clean.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'wanted' in d.devlibs and d.devlibs.wanted %}
         {%- for tool in d.devlibs.wanted|unique %}
             {%- if 'pkg' in d.devlibs and tool in d.devlibs['pkg'] and d.devlibs['pkg'][tool] %}
 
-{{ formula }}-devlibs-archive-{{ tool }}-clean:
+kubernetes-devlibs-archive-{{ tool }}-clean:
   file.absent:
     - names:
       - {{ d.devlibs['pkg'][tool]['path'] }}

--- a/kubernetes/devlibs/archive/install.sls
+++ b/kubernetes/devlibs/archive/install.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
 
     {%- if 'wanted' in d.devlibs and d.devlibs.wanted %}
 
         {%- if grains.os != 'Windows' %}
-{{ formula }}-devlibs-pkg-deps-install:
+kubernetes-devlibs-pkg-deps-install:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
         {%- endif %}
@@ -19,16 +18,16 @@
                 {%- set p = d.devlibs.pkg[tool] %}
                 {%- if p['use_upstream'] == 'archive' and 'archive' in p %}
 
-{{ formula }}-devlibs-archive-{{ tool }}-install:
+kubernetes-devlibs-archive-{{ tool }}-install:
   file.directory:
     - name: {{ p['path'] }}
     - clean: {{ d.clean }}
     - makedirs: True
     - require_in:
-      - archive: {{ formula }}-devlibs-archive-{{ tool }}-install
+      - archive: kubernetes-devlibs-archive-{{ tool }}-install
                    {%- if grains.os != 'Windows' %}
     - require:
-      - pkg: {{ formula }}-devlibs-pkg-deps-install
+      - pkg: kubernetes-devlibs-pkg-deps-install
     - mode: 755
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}

--- a/kubernetes/devtools/alternatives/clean.sls
+++ b/kubernetes/devtools/alternatives/clean.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- if 'wanted' in d.devtools and d.devtools.wanted %}
@@ -11,7 +10,7 @@
                 {%- if 'pkg' in d.devtools and tool in d.devtools['pkg'] and d.devtools['pkg'][tool] %}
                     {%- for cmd in d.devtools['pkg'][tool]['commands']|unique %}
 
-{{ formula }}-devtools-{{ tool }}-alternatives-clean-{{ cmd }}:
+kubernetes-devtools-{{ tool }}-alternatives-clean-{{ cmd }}:
   alternatives.remove:
     - name: link-k8s-devtools-{{ tool }}-{{ cmd }}
     - path: {{ d.devtools['pkg'][tool]['path'] }}/{{ cmd }}

--- a/kubernetes/devtools/alternatives/install.sls
+++ b/kubernetes/devtools/alternatives/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- set sls_archive_install = tplroot ~ '.devtools.archive.install' %}
@@ -18,7 +17,7 @@ include:
                 {%- if 'pkg' in d.devtools and tool in d.devtools['pkg'] and d.devtools['pkg'][tool] %}
                     {%- for cmd in d.devtools['pkg'][tool]['commands']|unique %}
 
-{{ formula }}-devtools-{{ tool }}-alternatives-install-bin-{{ cmd }}:
+kubernetes-devtools-{{ tool }}-alternatives-install-bin-{{ cmd }}:
                         {%- if grains.os_family in ('Suse', 'Arch') %}
   alternatives.install:
     - name: link-k8s-devtools-{{ tool }}-{{ cmd }}
@@ -37,9 +36,9 @@ include:
     - require:
       - sls: {{ sls_archive_install if d.devtools.pkg[tool]['use_upstream'] == 'archive' else sls_binary_install }}
     - require_in:
-      - alternatives: {{ formula }}-devtools-{{ tool }}-alternatives-set-bin-{{ cmd }}
+      - alternatives: kubernetes-devtools-{{ tool }}-alternatives-set-bin-{{ cmd }}
 
-{{ formula }}-devtools-{{ tool }}-alternatives-set-bin-{{ cmd }}:
+kubernetes-devtools-{{ tool }}-alternatives-set-bin-{{ cmd }}:
   alternatives.set:
     - unless: {{ grains.os_family in ('Suse', 'Arch') }} || false
     - name: link-k8s-devtools-{{ tool }}-{{ cmd }}

--- a/kubernetes/devtools/archive/clean.sls
+++ b/kubernetes/devtools/archive/clean.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'wanted' in d.devtools and d.devtools.wanted %}
         {%- for tool in d.devtools.wanted|unique %}
             {%- if 'pkg' in d.devtools and tool in d.devtools['pkg'] and d.devtools.pkg[tool] %}
 
-{{ formula }}-devtools-archive-{{ tool }}-clean:
+kubernetes-devtools-archive-{{ tool }}-clean:
   file.absent:
     - names:
       - "{{ d.devtools['pkg'][tool]['path'] }}"

--- a/kubernetes/devtools/archive/install.sls
+++ b/kubernetes/devtools/archive/install.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
 
     {%- if 'wanted' in d.devtools and d.devtools.wanted %}
 
         {%- if grains.os != 'Windows' %}
-{{ formula }}-devtools-pkg-deps-install:
+kubernetes-devtools-pkg-deps-install:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
         {%- endif %}
@@ -19,16 +18,16 @@
                 {%- set p = d.devtools.pkg[tool] %}
                 {%- if p['use_upstream'] == 'archive' and 'archive' in p %}
 
-{{ formula }}-devtools-archive-{{ tool }}-install:
+kubernetes-devtools-archive-{{ tool }}-install:
   file.directory:
     - name: {{ d.devtools['pkg'][tool]['path'] }}
     - clean: {{ d.clean }}
     - makedirs: True
     - require_in:
-      - archive: {{ formula }}-devtools-archive-{{ tool }}-install
+      - archive: kubernetes-devtools-archive-{{ tool }}-install
                      {%- if grains.os != 'Windows' %}
     - require:
-      - pkg: {{ formula }}-devtools-pkg-deps-install
+      - pkg: kubernetes-devtools-pkg-deps-install
     - mode: 755
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
@@ -58,15 +57,15 @@
                          {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                              {%- for cmd in d.devtools['pkg'][tool]['commands']|unique %}
 
-{{ formula }}-devtools-archive-{{ tool }}-install-symlink-{{ cmd }}:
+kubernetes-devtools-archive-{{ tool }}-install-symlink-{{ cmd }}:
   file.symlink:
     - name: /usr/local/bin/{{ cmd }}
-    - target: {{ d.devtools['pkg'][tool]['path'] }}/bin/{{ tool }}
+    - target: {{ d.devtools['pkg'][tool]['path'] }}/bin/{{ cmd }}
     - force: True
     - onlyif:
-      - test -f {{ d.devtools['pkg'][tool]['path'] }}/bin/{{ tool }}
+      - test -f {{ d.devtools['pkg'][tool]['path'] }}/bin/{{ cmd }}
     - require:
-      - archive: {{ formula }}-devtools-archive-{{ tool }}-install
+      - archive: kubernetes-devtools-archive-{{ tool }}-install
 
                              {%- endfor %}
                          {%- endif %}
@@ -76,7 +75,7 @@
         {%- endfor %}
         {%- if grains.os == 'Windows' %}
 
-{{ formula }}-devtools-archive-install-bashrc:
+kubernetes-devtools-archive-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -85,9 +84,9 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-devtools-archive-install-bashrc
+      - file: kubernetes-devtools-archive-install-bashrc
 
-{{ formula }}-devtools-archive-install-windows-tidyup:
+kubernetes-devtools-archive-install-windows-tidyup:
   cmd.run:
     - names:
       - mv {{ d.dir.base ~ d.div }}istio-{{ d.devtools.pkg.istio.version }}{{ d.div ~ 'bin' ~ d.div }}istioctl {{ d.dir.base ~ d.div ~ 'bin' ~ d.div }} || True  # noqa 204

--- a/kubernetes/devtools/binary/clean.sls
+++ b/kubernetes/devtools/binary/clean.sls
@@ -3,14 +3,13 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'wanted' in d.devtools and d.devtools.wanted %}
         {%- for tool in d.devtools.wanted|unique %}
             {%- if d.devtools.pkg[tool]['use_upstream'] == 'binary' %}
                 {%- if 'pkg' in d.devtools and tool in d.devtools['pkg'] and d.devtools['pkg'][tool] %}
 
-{{ formula }}-devtools-binary-{{ tool }}-clean:
+kubernetes-devtools-binary-{{ tool }}-clean:
   file.absent:
     - names:
       - "{{ d.devtools['pkg'][tool]['path'] }}"

--- a/kubernetes/devtools/binary/install.sls
+++ b/kubernetes/devtools/binary/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'wanted' in d.devtools and d.devtools.wanted %}
         {%- for tool in d.devtools.wanted|unique %}
@@ -11,7 +10,7 @@
                 {%- set p = d.devtools['pkg'] %}
                 {%- if 'binary' in p[tool] and 'source' in p[tool]['binary'] %}
 
-{{ formula }}-devtools-binary-{{ tool }}-install:
+kubernetes-devtools-binary-{{ tool }}-install:
   file.managed:
     - name: {{ p[tool]['path'] }}{{ tool }}
     - source: {{ p[tool]['binary']['source'] }}
@@ -39,7 +38,7 @@
                         {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                             {%- for cmd in p[tool]['commands']|unique %}
 
-{{ formula }}-devtools-binary-{{ tool }}-install-symlink-{{ cmd }}:
+kubernetes-devtools-binary-{{ tool }}-install-symlink-{{ cmd }}:
   file.symlink:
     - name: /usr/local/bin/{{ cmd }}
     - target: {{ p[tool]['path'] }}{{ tool }}/bin/{{ cmd }}
@@ -47,7 +46,7 @@
     - onlyif:
       - test -f {{ p[tool]['path'] }}{{ tool }}/bin/{{ cmd }}
     - require:
-      - file: {{ formula }}-devtools-binary-{{ tool }}-install
+      - file: kubernetes-devtools-binary-{{ tool }}-install
                             {%- endfor %}
                         {%- endif %}
                     {%- endif %}
@@ -56,7 +55,7 @@
         {%- endfor %}
         {%- if grains.os|lower == 'windows' %}
 
-{{ formula }}-devtools-binary-install-bashrc:
+kubernetes-devtools-binary-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -65,7 +64,7 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-devtools-binary-install-bashrc
+      - file: kubernetes-devtools-binary-install-bashrc
 
         {%- endif %}
     {%- endif %}

--- a/kubernetes/init.sls
+++ b/kubernetes/init.sls
@@ -11,3 +11,4 @@ include:
   - .devtools
   - .devlibs
   - .sigs
+  - .managers

--- a/kubernetes/init.sls
+++ b/kubernetes/init.sls
@@ -11,4 +11,4 @@ include:
   - .devtools
   - .devlibs
   - .sigs
-  - .managers
+  - .crimgr

--- a/kubernetes/k3s/alternatives/clean.sls
+++ b/kubernetes/k3s/alternatives/clean.sls
@@ -3,12 +3,11 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- for cmd in d.k3s['pkg']['commands']|unique %}
 
-{{ formula }}-k3s-alternatives-clean-{{ cmd }}:
+kubernetes-k3s-alternatives-clean-{{ cmd }}:
   alternatives.remove:
     - name: link-k8s-k3s-{{ cmd }}
     - path: {{ d.k3s['pkg']['path'] }}/{{ cmd }}

--- a/kubernetes/k3s/alternatives/install.sls
+++ b/kubernetes/k3s/alternatives/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- set sls_script_install = tplroot ~ '.k3s.script.install' %}
@@ -15,7 +14,7 @@ include:
 
         {%- for cmd in d.k3s['pkg']['commands']|unique %}
 
-{{ formula }}-k3s-alternatives-install-bin-{{ cmd }}:
+kubernetes-k3s-alternatives-install-bin-{{ cmd }}:
             {%- if grains.os_family in ('Suse', 'Arch') %}
   alternatives.install:
     - name: link-k8s-k3s-{{ cmd }}
@@ -34,9 +33,9 @@ include:
     - require:
       - sls: {{ sls_script_install if d.k3s.pkg['use_upstream'] == 'script' else sls_binary_install }}
     - require_in:
-      - alternatives: {{ formula }}-k3s-alternatives-set-bin-{{ cmd }}
+      - alternatives: kubernetes-k3s-alternatives-set-bin-{{ cmd }}
 
-{{ formula }}-k3s-alternatives-set-bin-{{ cmd }}:
+kubernetes-k3s-alternatives-set-bin-{{ cmd }}:
   alternatives.set:
     - unless: {{ grains.os_family in ('Suse', 'Arch') }} || false
     - name: link-k8s-k3s-{{ cmd }}

--- a/kubernetes/k3s/binary/clean.sls
+++ b/kubernetes/k3s/binary/clean.sls
@@ -3,9 +3,8 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
-{{ formula }}-k3s-binary-clean:
+kubernetes-k3s-binary-clean:
   file.absent:
     - names:
       - /usr/local/bin/k3s

--- a/kubernetes/k3s/binary/install.sls
+++ b/kubernetes/k3s/binary/install.sls
@@ -3,16 +3,15 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.k3s.pkg.use_upstream == 'binary' %}
 
-{{ formula }}-k3s-binary-install:
+kubernetes-k3s-binary-install:
         {%- if grains.os|lower != 'windows' %}
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     - require_in:
-      - file: {{ formula }}-k3s-binary-install
+      - file: kubernetes-k3s-binary-install
         {%- endif %}
   file.managed:
     - name: {{ d.k3s.pkg.path }}k3s
@@ -28,13 +27,13 @@
             {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                 {%- for cmd in d.k3s.pkg['commands']|unique %}
 
-{{ formula }}-k3s-binary-install-symlink:
+kubernetes-k3s-binary-install-symlink:
   file.symlink:
     - name: /usr/local/bin/k3s
     - target: {{ d.k3s.pkg.path }}/k3s
     - force: True
     - require:
-      - file: {{ formula }}-k3s-binary-install
+      - file: kubernetes-k3s-binary-install
     - unless: {{ d.linux.altpriority|int > 0 }} || false
 
                 {%- endfor %}
@@ -45,7 +44,7 @@
     - name: mv {{ d.k3s.pkg.path }}k3s {{ d.k3s.pkg.path }}k3s.exe
     - onlyif: test -f {{ d.k3s.pkg.path }}k3s
 
-{{ formula }}-k3s-archive-install-bashrc:
+kubernetes-k3s-archive-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -54,7 +53,7 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-k3s-archive-install-bashrc
+      - file: kubernetes-k3s-archive-install-bashrc
 
         {%- endif %}
     {%- endif %}

--- a/kubernetes/k3s/config/clean.sls
+++ b/kubernetes/k3s/config/clean.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'config_file' in d.k3s and d.k3s.config_file %}
         {%- set sls_binary_clean = tplroot ~ '.k3s.binary.clean' %}
@@ -12,7 +11,7 @@
 include:
   - {{ sls_archive_clean if d.k3s.pkg.use_upstream == 'archive' else sls_script_clean }}
 
-{{ formula }}-k3s-config-clean:
+kubernetes-k3s-config-clean:
   file.absent:
     - names:
       - {{ d.k3s.config_file }}

--- a/kubernetes/k3s/config/file.sls
+++ b/kubernetes/k3s/config/file.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if 'config' in d.k3s and d.k3s.config %}
     {%- set sls_archive_install = tplroot ~ '.k3s.archive.install' %}
@@ -14,7 +13,7 @@
 include:
   - {{ sls_archive_install if d.k3s.pkg.use_upstream == 'archive' else sls_binary_install if d.k3s.pkg.use_upstream == 'binary' else sls_package_install }}   # noqa 204
 
-{{ formula }}-k3s-config-file-install-file-managed:
+kubernetes-k3s-config-file-install-file-managed:
   file.managed:
     - name: {{ d.k3s.config_file }}
     - source: {{ files_switch(['config.yml.jinja'],

--- a/kubernetes/k3s/script/clean.sls
+++ b/kubernetes/k3s/script/clean.sls
@@ -3,18 +3,17 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.k3s.pkg.use_upstream == 'script' %}
         {%- if grains.os_family not in ('Redhat',) %}
 
-{{ formula }}-k3s-script-clean-killall:
+kubernetes-k3s-script-clean-killall:
   cmd.run:
     - name: {{ d.k3s.pkg.script.killall }}
     - onlyif:
       - test -f {{ d.k3s.pkg.script.killall }}
 
-{{ formula }}-k3s-script-clean-uninstall:
+kubernetes-k3s-script-clean-uninstall:
   cmd.run:
     - names:
       - sleep 15
@@ -22,19 +21,19 @@
     - onlyif:
       - test -f {{ d.k3s.pkg.script.uninstall }}
 
-{{ formula }}-k3s-script-clean-file-absent:
+kubernetes-k3s-script-clean-file-absent:
   file.absent:
     - names:
       - {{ d.dir.tmp }}
       - {{ d.k3s.pkg.script.killall }}
       - {{ d.k3s.pkg.script.uninstall }}
     - require:
-      - cmd: {{ formula }}-k3s-script-clean-killall
-      - cmd: {{ formula }}-k3s-script-clean-uninstall
+      - cmd: kubernetes-k3s-script-clean-killall
+      - cmd: kubernetes-k3s-script-clean-uninstall
 
         {%- else %}
 
-{{ formula }}-k3s-package-uninstall-other:
+kubernetes-k3s-package-uninstall-other:
   test.show_notification:
     - text: |
         The k3s package is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}

--- a/kubernetes/k3s/script/install.sls
+++ b/kubernetes/k3s/script/install.sls
@@ -3,12 +3,11 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if d.k3s.pkg.use_upstream == 'script' %}
 
     {%- if grains.os_family not in ('RedHat', 'Windows') %}
-{{ formula }}-k3s-script-install-prerequisites:
+kubernetes-k3s-script-install-prerequisites:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
           {%- if grains.os_family in ('CentOS',) and d.k3s.pkg.deps_url %}
@@ -18,39 +17,39 @@
       - yum install -y {{ pkg }}
               {%- endfor %}
     - require_in:
-      - file: {{ formula }}-k3s-script-install-prerequisites
+      - file: kubernetes-k3s-script-install-prerequisites
           {%- endif %}
   file.directory:
     - name: {{ d.dir.tmp }}
     - makedirs: True
     - require:
-      - pkg: {{ formula }}-k3s-script-install-prerequisites
+      - pkg: kubernetes-k3s-script-install-prerequisites
               {%- if grains.os != 'Windows' %}
     - mode: '0755'
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
               {%- endif %}
 
-{{ formula }}-k3s-script-download:
+kubernetes-k3s-script-download:
   file.managed:
     - name: {{ d.dir.tmp }}/k3s-bootstrap.sh
     - source: {{ d.k3s.pkg.script.source }}
     - source_hash: {{ d.k3s.pkg.script.source_hash }}
     - require:
-      - file: {{ formula }}-k3s-script-install-prerequisites
+      - file: kubernetes-k3s-script-install-prerequisites
               {%- if grains.os != 'Windows' %}
     - mode: 755
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
               {%- endif %}
 
-{{ formula }}-k3s-script-download-clean:
+kubernetes-k3s-script-download-clean:
   file.absent:
     - name: {{ d.dir.tmp }}/k3s-bootstrap.sh
     - onfail:
-      - file: {{ formula }}-k3s-script-download
+      - file: kubernetes-k3s-script-download
 
-{{ formula }}-k3s-script-install:
+kubernetes-k3s-script-install:
   cmd.run:
     - name: {{ d.dir.tmp }}/k3s-bootstrap.sh
           {%- if 'env' in d.k3s.pkg.script and d.k3s.pkg.script.env %}
@@ -60,11 +59,11 @@
               {%- endfor %}
           {%- endif %}
     - require:
-      - file: {{ formula }}-k3s-script-download
+      - file: kubernetes-k3s-script-download
 
     {%- else %}
 
-{{ formula }}-k3s-package-install-other:
+kubernetes-k3s-package-install-other:
   test.show_notification:
     - text: |
         The k3s package is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}

--- a/kubernetes/map.jinja
+++ b/kubernetes/map.jinja
@@ -32,7 +32,7 @@
 {%- for c in d.supported %}
     {%- set path = d.dir.base %}
     {%- set url = False %}
-    {%- set list = ('client', 'server', 'node', 'k3s') %}
+    {%- set list = ('client', 'server', 'node', 'k3s', 'crimgr') %}
     {%- if c in list and c in d and d[c] and 'pkg' in d[c] and 'version' in d[c] %}
         {%- set p = d[c]['pkg'] %}
 
@@ -45,8 +45,14 @@
                 {%- do p.update({ 'path': '%sk8s-%s-%s%s'|format(d.dir.base, c, d[c]['version'], d.div) }) %}
             {%- endif %}
 
-            {%- set uri = '%s/v%s/kubernetes-%s-%s'|format(p.uri_a, d[c]['version'], c, grains.kernel|lower) %}
-            {%- set url = '%s-%s.%s'|format(uri, d.arch, p.suffix) %}
+            {%- if c in ('crimgr',) %}
+                {%- set arch = 'x86_64' if c in ('crimgr',) and d.arch == 'amd64' else d.arch %}
+                {%- set url = '%s/v%s/cri-resource-manager-%s.%s.%s'|format(p.uri_a, d[c]['version'], d[c]['version'], arch, p.suffix) %}
+            {%- else %}
+            {%- set arch = d.arch %}
+                {%- set uri = '%s/v%s/kubernetes-%s-%s'|format(p.uri_a, d[c]['version'], c, grains.kernel|lower) %}
+                {%- set url = '%s-%s.%s'|format(uri, arch, p.suffix) %}
+            {%- endif %}
             {%- do p.archive.update({ 'name': p.path, 'source': url }) %}
 
             {%- if 'source_hash' in p.archive and p.archive.source_hash %}
@@ -152,9 +158,9 @@
         {%- endfor %}
     {%- endif %}
 
-    ## SIGS / DEVTOOLS / DEVLIBS / OPERATORS / MANAGERS ##
+    ## SIGS / DEVTOOLS / DEVLIBS / OPERATORS ##
     {%- set path = d.dir.source if c in ('devlibs', 'operators') else d.dir.base %}
-    {%- set list = ('devlibs', 'operators', 'sigs', 'devtools', 'managers') %}
+    {%- set list = ('devlibs', 'operators', 'sigs', 'devtools') %}
 
     {%- if c in list and c in d and d[c] and 'pkg' in d[c] and d[c]['pkg'] %}
         {%- for i in d[c]['wanted'] %}
@@ -193,10 +199,6 @@
                         {%- set arch = 'amd64' if i in ('stern',) and d.arch == 'x86_64' else d.arch %}
                         {%- set url = '%s/%s/%s_%s_%s'|format(p.uri_a, p.version, i, grains.kernel, arch) %}
 
-                    {%- elif i in ('cri_resource_manager',) %}
-                        {%- set arch = 'x86_64' if i in ('cri_resource_manager',) and d.arch == 'amd64' else d.arch %}
-                        {%- set url = '%s/v%s/%s-%s.%s.%s'|format(p.uri_a, p.version, i|replace('_', '-'), arch, p.suffix) %}
-
                     {%- elif i in ('istio',) %}
                         {%- set kernel = 'osx' if grains.kernel == 'Darwin' else grains.kernel|lower %}
                         {%- set kernel = 'win' if kernel|lower == 'windows' else kernel %}
@@ -228,8 +230,6 @@
                         {%- do p.update({ 'path': '%sk8s-%s-%s-%s%s'|format(path, c, i, p.version, d.div) }) %}
                         {%- if i in ('audit2rbac', 'cue', 'dive', 'istio', 'kubens', 'kubectx', 'octant', 'krew') %}
                             {%- do p.update({ 'path': '%s%sbin%s'|format(p.path, d.div, d.div) }) %}
-			{%- elif i in ('cri_resource_manager',) %}
-                            {%- do p.update({ 'path': '/'}) %}
                         {%- endif %}
                     {%- endif %}
 

--- a/kubernetes/map.jinja
+++ b/kubernetes/map.jinja
@@ -152,9 +152,9 @@
         {%- endfor %}
     {%- endif %}
 
-    ## SIGS / DEVTOOLS / DEVLIBS / OPERATORS ##
+    ## SIGS / DEVTOOLS / DEVLIBS / OPERATORS / MANAGERS ##
     {%- set path = d.dir.source if c in ('devlibs', 'operators') else d.dir.base %}
-    {%- set list = ('devlibs', 'operators', 'sigs', 'devtools') %}
+    {%- set list = ('devlibs', 'operators', 'sigs', 'devtools', 'managers') %}
 
     {%- if c in list and c in d and d[c] and 'pkg' in d[c] and d[c]['pkg'] %}
         {%- for i in d[c]['wanted'] %}
@@ -193,6 +193,10 @@
                         {%- set arch = 'amd64' if i in ('stern',) and d.arch == 'x86_64' else d.arch %}
                         {%- set url = '%s/%s/%s_%s_%s'|format(p.uri_a, p.version, i, grains.kernel, arch) %}
 
+                    {%- elif i in ('cri_resource_manager',) %}
+                        {%- set arch = 'x86_64' if i in ('cri_resource_manager',) and d.arch == 'amd64' else d.arch %}
+                        {%- set url = '%s/v%s/%s-%s.%s.%s'|format(p.uri_a, p.version, i|replace('_', '-'), arch, p.suffix) %}
+
                     {%- elif i in ('istio',) %}
                         {%- set kernel = 'osx' if grains.kernel == 'Darwin' else grains.kernel|lower %}
                         {%- set kernel = 'win' if kernel|lower == 'windows' else kernel %}
@@ -224,6 +228,8 @@
                         {%- do p.update({ 'path': '%sk8s-%s-%s-%s%s'|format(path, c, i, p.version, d.div) }) %}
                         {%- if i in ('audit2rbac', 'cue', 'dive', 'istio', 'kubens', 'kubectx', 'octant', 'krew') %}
                             {%- do p.update({ 'path': '%s%sbin%s'|format(p.path, d.div, d.div) }) %}
+			{%- elif i in ('cri_resource_manager',) %}
+                            {%- do p.update({ 'path': '/'}) %}
                         {%- endif %}
                     {%- endif %}
 

--- a/kubernetes/node/alternatives/clean.sls
+++ b/kubernetes/node/alternatives/clean.sls
@@ -3,12 +3,11 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {% from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- for cmd in d.node.pkg.commands|unique %}
 
-{{ formula }}-node-alternatives-clean-{{ cmd }}:
+kubernetes-node-alternatives-clean-{{ cmd }}:
   alternatives.remove:
     - name: link-k8s-node-{{ cmd }}
     - path: {{ d.node.pkg.path }}/bin/{{ cmd }}

--- a/kubernetes/node/alternatives/install.sls
+++ b/kubernetes/node/alternatives/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- set sls_archive_install = tplroot ~ '.node.archive.install' %}
@@ -14,7 +13,7 @@ include:
   - {{ sls_package_install }}
 
         {%- for cmd in d.node.pkg.commands|unique %}
-{{ formula }}-node-alternatives-install-bin-{{ cmd }}:
+kubernetes-node-alternatives-install-bin-{{ cmd }}:
             {%- if grains.os_family not in ('Suse', 'Arch') %}
   alternatives.install:
     - name: link-k8s-node-{{ cmd }}
@@ -36,9 +35,9 @@ include:
     - require:
       - sls: {{ sls_archive_install if d.client.pkg.use_upstream == 'archive' else sls_binary_install }}
     - require_in:
-      - alternatives: {{ formula }}-node-alternatives-set-bin-{{ cmd }}
+      - alternatives: kubernetes-node-alternatives-set-bin-{{ cmd }}
 
-{{ formula }}-node-alternatives-set-bin-{{ cmd }}:
+kubernetes-node-alternatives-set-bin-{{ cmd }}:
   alternatives.set:
     - unless:
       - {{ grains.os_family in ('Suse', 'Arch') }} || false

--- a/kubernetes/node/archive/clean.sls
+++ b/kubernetes/node/archive/clean.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- set sls_alternatives_clean = tplroot ~ '.node.alternatives.clean' %}
 include:
   - {{ sls_alternatives_clean }}
 
-{{ formula }}-node-archive-absent:
+kubernetes-node-archive-absent:
   file.absent:
     - names:
       - {{ d.dir.tmp }}/kubernetes-node*

--- a/kubernetes/node/archive/install.sls
+++ b/kubernetes/node/archive/install.sls
@@ -3,24 +3,23 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
 
     {%- if d.node.pkg.use_upstream == 'archive' and 'archive' in d.node.pkg %}
 
-{{ formula }}-node-archive-install:
+kubernetes-node-archive-install:
         {%- if grains.os|lower != 'windows' %}
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     - require_in:
-      - file: {{ formula }}-node-archive-install
+      - file: kubernetes-node-archive-install
         {%- endif %}
   file.directory:
     - name: {{ d.node.pkg.path }}
     - makedirs: True
     - clean: False   # don't
     - require_in:
-      - archive: {{ formula }}-node-archive-install
+      - archive: kubernetes-node-archive-install
         {%- if grains.os|lower != 'windows' %}
     - mode: 755
     - user: {{ d.identity.rootuser }}
@@ -38,7 +37,7 @@
     - force: true
     - overwrite: {{ d.overwrite }}
     - require:
-      - file: {{ formula }}-node-archive-install
+      - file: kubernetes-node-archive-install
         {%- if grains.os|lower != 'windows' %}
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
@@ -48,19 +47,19 @@
             {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                 {%- for cmd in d.node.pkg.commands|unique %}
 
-{{ formula }}-node-archive-install-symlink-{{ cmd }}:
+kubernetes-node-archive-install-symlink-{{ cmd }}:
   file.symlink:
     - name: /usr/local/bin/{{ cmd }}
     - target: {{ d.node.pkg.path }}/bin/{{ cmd }}
     - force: True
     - require:
-      - archive: {{ formula }}-node-archive-install
+      - archive: kubernetes-node-archive-install
 
                 {%- endfor %}
             {%- endif %}
         {%- elif grains.os|lower == 'windows' %}
 
-{{ formula }}-node-archive-install-bashrc:
+kubernetes-node-archive-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -69,9 +68,9 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-node-archive-install-bashrc
+      - file: kubernetes-node-archive-install-bashrc
 
-{{ formula }}-node-archive-install-windows-tidyup:
+kubernetes-node-archive-install-windows-tidyup:
   cmd.run:
     - name: mv {{ d.dir.base ~ d.div ~ 'bin' ~ d.div }}*.exe {{ d.dir.base ~ d.div ~ 'bin' ~ d.div }} || True
     - onlyif: test -d {{ d.dir.base ~ d.div ~ 'bin' ~ d.div }}

--- a/kubernetes/node/config/clean.sls
+++ b/kubernetes/node/config/clean.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- set sls_archive_clean = tplroot ~ '.node.archive.clean' %}
 {%- set sls_package_clean = tplroot ~ '.node.package.clean' %}
@@ -12,7 +11,7 @@ include:
   - {{ sls_archive_clean }}
   - {{ sls_package_clean }}
 
-{{ formula }}-node-config-clean:
+kubernetes-node-config-clean:
   file.absent:
     - names:
       - {{ d.node.config_file }}

--- a/kubernetes/node/config/environ.sls
+++ b/kubernetes/node/config/environ.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if 'environ' in d.node and d.node.environ %}
     {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
@@ -13,7 +12,7 @@
 include:
   - {{ sls_archive_install if d.node.pkg.use_upstream == 'archive' else sls_package_install }}
 
-{{ formula }}-node-config-file-managed-environ_file:
+kubernetes-node-config-file-managed-environ_file:
   file.managed:
     - name: {{ d.node.environ_file }}
     - source: {{ files_switch(['environ.sh.jinja'],

--- a/kubernetes/node/config/file.sls
+++ b/kubernetes/node/config/file.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if 'config' in d.node and d.node.config %}
     {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
@@ -13,7 +12,7 @@
 include:
   - {{ sls_archive_install if d.node.pkg.use_upstream == 'archive' else sls_package_install }}
 
-{{ formula }}-node-config-file-install-file-managed:
+kubernetes-node-config-file-install-file-managed:
   file.managed:
     - name: {{ d.node.config_file }}
     - source: {{ files_switch(['config.yml.jinja'],

--- a/kubernetes/node/package/clean.sls
+++ b/kubernetes/node/package/clean.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.node.pkg.use_upstream in ('package', 'repo') %}
         {%- if grains.os_family|lower in ('redhat', 'debian') %}
@@ -13,13 +12,13 @@ include:
   - {{ sls_repo_clean }}
             {%- endif %}
 
-{{ formula }}-node-package-clean-pkgs:
+kubernetes-node-package-clean-pkgs:
   pkg.removed:
     - names: {{ d.node.pkg.commands|unique|json }}
     - reload_modules: true
             {%- if d.node.pkg.use_upstream == 'repo' %}
     - require:
-      - pkgrepo: {{ formula }}-package-repo-absent
+      - pkgrepo: kubernetes-package-repo-absent
             {%- endif %}
 
         {%- endif %}

--- a/kubernetes/node/package/install.sls
+++ b/kubernetes/node/package/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.node.pkg.use_upstream in ('package', 'repo') %}
         {%- if grains.os_family|lower in ('redhat', 'debian') %}
@@ -13,23 +12,23 @@ include:
   - {{ sls_repo_install }}
             {%- endif %}
 
-{{ formula }}-node-package-install-deps:
+kubernetes-node-package-install-deps:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
 
-{{ formula }}-node-package-install-pkgs:
+kubernetes-node-package-install-pkgs:
   pkg.installed:
     - names: {{ d.node.pkg.commands|unique|json }}
     - runas: {{ d.identity.rootuser }}
     - reload_modules: true
             {%- if d.node.pkg.use_upstream == 'repo' %}
     - require:
-      - pkgrepo: {{ formula }}-package-repo-managed
+      - pkgrepo: kubernetes-package-repo-managed
             {%- endif %}
 
         {%- else %}
 
-{{ formula }}-node-package-install-other:
+kubernetes-node-package-install-other:
   test.show_notification:
     - text: |
         The node package is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}

--- a/kubernetes/operator/sdk/binary/clean.sls
+++ b/kubernetes/operator/sdk/binary/clean.sls
@@ -5,7 +5,6 @@
 
     {%- set tplroot = tpldir.split('/')[0] %}
     {%- from tplroot ~ "/map.jinja" import data as d with context %}
-    {%- set formula = d.formula %}
 
     {%- if 'wanted' in d.operator.sdk and d.operator.sdk.wanted %}
         {%- for item in d.operator.sdk.wanted|unique %}
@@ -13,7 +12,7 @@
                 {%- set p = d.operator.sdk['pkg'] %}
                 {%- if item in p and 'binary' in p[item] and 'source' in p[item]['binary'] %}
 
-{{ formula }}-operator-sdk-binary-{{ item }}-clean:
+kubernetes-operator-sdk-binary-{{ item }}-clean:
   file.absent:
     - name: {{ p[item]['path'] }}/{{ item }}
 

--- a/kubernetes/operator/sdk/binary/install.sls
+++ b/kubernetes/operator/sdk/binary/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if grains.kernel|lower in ('linux', 'darwin', 'windows') %}
     {%- if 'wanted' in d.operator.sdk and d.operator.sdk.wanted %}
@@ -12,7 +11,7 @@
                 {%- set p = d.operator.sdk['pkg'] %}
                 {%- if item in p and 'binary' in p[item] and 'source' in p[item]['binary'] %}
 
-{{ formula }}-operator-sdk-binary-{{ item }}-install:
+kubernetes-operator-sdk-binary-{{ item }}-install:
   file.managed:
     - name: {{ p[item]['path'] }}{{ item }}
     - source: {{ p[item]['binary']['source'] }}
@@ -30,7 +29,7 @@
       - mode
                     {%- endif %}
 
-{{ formula }}-operator-sdk-binary-{{ item }}-verify:
+kubernetes-operator-sdk-binary-{{ item }}-verify:
   file.managed:
     - name: {{ p[item]['path'] }}/{{ item }}.asc
     - source: {{ p[item]['binary']['source_hash'] }}
@@ -53,16 +52,16 @@
       - gpg --verify {{ p[item]['path'] }}{{ item }}.asc
       - rm {{ p[item]['path'] }}{{ item }}.asc
     - require:
-      - file: {{ formula }}-operator-sdk-binary-{{ item }}-install
-      - file: {{ formula }}-operator-sdk-binary-{{ item }}-verify
+      - file: kubernetes-operator-sdk-binary-{{ item }}-install
+      - file: kubernetes-operator-sdk-binary-{{ item }}-verify
 
-{{ formula }}-operator-sdk-binary-{{ item }}-failure:
+kubernetes-operator-sdk-binary-{{ item }}-failure:
   file.absent:
     - names:
       - {{ p[item]['path'] }}{{ item }}
       - {{ p[item]['path'] }}{{ item }}.asc
     - onfail:
-      - cmd: {{ formula }}-operator-sdk-binary-{{ item }}-verify
+      - cmd: kubernetes-operator-sdk-binary-{{ item }}-verify
 
                 {%- endif %}
             {%- endif %}

--- a/kubernetes/operators/archive/clean.sls
+++ b/kubernetes/operators/archive/clean.sls
@@ -3,14 +3,13 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'wanted' in d.operators and d.operators.wanted %}
         {%- for tool in d.operators.wanted|unique %}
             {%- if d.operators.pkg[tool]['use_upstream'] == 'archive' %}
                 {%- if 'pkg' in d.operators and tool in d.operators['pkg'] and d.operators['pkg'][tool] %}
 
-{{ formula }}-operators-archive-{{ tool }}-clean:
+kubernetes-operators-archive-{{ tool }}-clean:
   file.absent:
     - names:
       - {{ d.operators['pkg'][tool]['path'] }}

--- a/kubernetes/operators/archive/install.sls
+++ b/kubernetes/operators/archive/install.sls
@@ -3,12 +3,11 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
 
     {%- if grains.os != 'Windows' %}
-{{ formula }}-operators-archive-deps-install:
+kubernetes-operators-archive-deps-install:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     {%- endif %}
@@ -18,16 +17,16 @@
             {%- if 'pkg' in d.operators and tool in d.operators['pkg'] and d.operators.pkg[tool] %}
                 {%- if d.operators.pkg[tool]['use_upstream'] == 'archive' and 'archive' in d.operators.pkg[tool] %}
 
-{{ formula }}-operators-archive-{{ tool }}-install:
+kubernetes-operators-archive-{{ tool }}-install:
   file.directory:
     - name: {{ d.operators.pkg[tool]['path'] }}
     - clean: {{ d.clean }}
     - makedirs: True
     - require_in:
-      - archive: {{ formula }}-operators-archive-{{ tool }}-install
+      - archive: kubernetes-operators-archive-{{ tool }}-install
                    {%- if grains.os != 'Windows' %}
     - require:
-      - pkg: {{ formula }}-operators-archive-deps-install
+      - pkg: kubernetes-operators-archive-deps-install
     - mode: 755
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}

--- a/kubernetes/package/repo/clean.sls
+++ b/kubernetes/package/repo/clean.sls
@@ -3,9 +3,8 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
-{{ formula }}-package-repo-absent:
+kubernetes-package-repo-absent:
   pkgrepo.absent:
     - name: {{ d.pkg.repo.name }}
     - onlyif:

--- a/kubernetes/package/repo/install.sls
+++ b/kubernetes/package/repo/install.sls
@@ -3,11 +3,9 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
-
 {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
 
-{{ formula }}-package-repo-managed:
+kubernetes-package-repo-managed:
   pkgrepo.managed:
     {{- format_kwargs(d.pkg.repo) }}
     - onlyif:

--- a/kubernetes/server/alternatives/clean.sls
+++ b/kubernetes/server/alternatives/clean.sls
@@ -3,12 +3,11 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- for cmd in d.server.pkg.commands|unique %}
 
-{{ formula }}-server-alternatives-clean-{{ cmd }}:
+kubernetes-server-alternatives-clean-{{ cmd }}:
   alternatives.remove:
     - name: link-k8s-server-{{ cmd }}
     - path: {{ d.server.pkg.path }}/bin/{{ cmd }}

--- a/kubernetes/server/alternatives/install.sls
+++ b/kubernetes/server/alternatives/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- set sls_archive_install = tplroot ~ '.server.archive.install' %}
@@ -14,7 +13,7 @@ include:
   - {{ sls_package_install }}
 
         {%- for cmd in d.server.pkg.commands|unique %}
-{{ formula }}-server-alternatives-install-bin-{{ cmd }}:
+kubernetes-server-alternatives-install-bin-{{ cmd }}:
             {%- if grains.os_family not in ('Suse', 'Arch') %}
   alternatives.install:
     - name: link-k8s-server-{{ cmd }}
@@ -36,9 +35,9 @@ include:
     - require:
       - sls: {{ sls_archive_install if d.client.pkg.use_upstream == 'archive' else sls_binary_install }}
     - require_in:
-      - alternatives: {{ formula }}-server-alternatives-set-bin-{{ cmd }}
+      - alternatives: kubernetes-server-alternatives-set-bin-{{ cmd }}
 
-{{ formula }}-server-alternatives-set-bin-{{ cmd }}:
+kubernetes-server-alternatives-set-bin-{{ cmd }}:
   alternatives.set:
     - unless:
       - {{ grains.os_family in ('Suse', 'Arch') }} || false

--- a/kubernetes/server/archive/clean.sls
+++ b/kubernetes/server/archive/clean.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- set sls_alternatives_clean = tplroot ~ '.server.alternatives.clean' %}
 include:
   - {{ sls_alternatives_clean }}
 
-{{ formula }}-server-archive-absent:
+kubernetes-server-archive-absent:
   file.absent:
     - names:
       - {{ d.dir.tmp }}/kubernetes-server

--- a/kubernetes/server/archive/install.sls
+++ b/kubernetes/server/archive/install.sls
@@ -3,23 +3,22 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if grains.kernel|lower in ('linux', 'darwin') %}
         {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
         {%- if d.server.pkg['use_upstream'] == 'archive' and 'archive' in d.server.pkg %}
 
-{{ formula }}-server-archive-install:
+kubernetes-server-archive-install:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     - require_in:
-      - file: {{ formula }}-server-archive-install
+      - file: kubernetes-server-archive-install
   file.directory:
     - name: {{ d.server.pkg.path }}
     - makedirs: True
     - clean: {{ d.clean }}
     - require_in:
-      - archive: {{ formula }}-server-archive-install
+      - archive: kubernetes-server-archive-install
     - mode: 755
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
@@ -33,7 +32,7 @@
     - enforce_toplevel: false
     - trim_output: true
     - require:
-      - file: {{ formula }}-server-archive-install
+      - file: kubernetes-server-archive-install
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
     - recurse:
@@ -42,20 +41,20 @@
             {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                 {%- for cmd in d.server.pkg.commands|unique %}
 
-{{ formula }}-server-archive-install-symlink-{{ cmd }}:
+kubernetes-server-archive-install-symlink-{{ cmd }}:
   file.symlink:
     - name: /usr/local/bin/{{ cmd }}
     - target: {{ d.server.pkg.path }}/bin/{{ cmd }}
     - force: True
     - require:
-      - archive: {{ formula }}-server-archive-install
+      - archive: kubernetes-server-archive-install
 
                 {%- endfor %}
             {%- endif %}
         {%- endif %}
     {%- else %}
 
-{{ formula }}-server-archive-install-other:
+kubernetes-server-archive-install-other:
   test.show_notification:
     - text: |
         The server archive is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}

--- a/kubernetes/server/config/clean.sls
+++ b/kubernetes/server/config/clean.sls
@@ -3,15 +3,13 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
-
 {%- set sls_archive_clean = tplroot ~ '.server.archive.clean' %}
 {%- set sls_package_clean = tplroot ~ '.server.package.clean' %}
 
 include:
   - {{ sls_archive_clean if d.server.pkg.use_upstream == 'archive' else sls_package_clean }}
 
-{{ formula }}-server-config-clean:
+kubernetes-server-config-clean:
   file.absent:
     - names:
       - {{ d.server.config_file }}

--- a/kubernetes/server/config/environ.sls
+++ b/kubernetes/server/config/environ.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if 'environ' in d.server and d.server.environ %}
     {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
@@ -13,7 +12,7 @@
 include:
   - {{ sls_archive_install if d.server.pkg.use_upstream == 'archive' else sls_package_install }}
 
-{{ formula }}-server-config-file-managed-environ_file:
+kubernetes-server-config-file-managed-environ_file:
   file.managed:
     - name: {{ d.server.environ_file }}
     - source: {{ files_switch(['environ.sh.jinja'],

--- a/kubernetes/server/config/file.sls
+++ b/kubernetes/server/config/file.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
 {%- if 'config' in d.server and d.server.config %}
     {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
@@ -13,7 +12,7 @@
 include:
   - {{ sls_archive_install if d.server.pkg.use_upstream == 'archive' else sls_package_install }}
 
-{{ formula }}-server-config-file-install-file-managed:
+kubernetes-server-config-file-install-file-managed:
   file.managed:
     - name: {{ d.server.config_file }}
     - source: {{ files_switch(['config.yml.jinja'],

--- a/kubernetes/server/init.sls
+++ b/kubernetes/server/init.sls
@@ -12,9 +12,8 @@ include:
     {%- else %}
         {%- set tplroot = tpldir.split('/')[0] %}
         {%- from tplroot ~ "/map.jinja" import data as d with context %}
-        {%- set formula = d.formula %}
 
-{{ formula }}-server-archive-install-other:
+kubernetes-server-archive-install-other:
   test.show_notification:
     - text: |
         The server is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}

--- a/kubernetes/server/package/clean.sls
+++ b/kubernetes/server/package/clean.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.server.pkg.use_upstream in ('package', 'repo') %}
         {%- if grains.os_family|lower in ('redhat', 'debian') %}
@@ -13,13 +12,13 @@ include:
   - {{ sls_repo_clean }}
             {%- endif %}
 
-{{ formula }}-server-package-clean-pkgs:
+kubernetes-server-package-clean-pkgs:
   pkg.removed:
     - names: {{ d.server.pkg.commands|unique|json }}
     - reload_modules: true
            {%- if d.server.pkg.use_upstream == 'repo' %}
     - require:
-      - pkgrepo: {{ formula }}-package-repo-absent
+      - pkgrepo: kubernetes-package-repo-absent
             {%- endif %}
 
         {%- endif %}

--- a/kubernetes/server/package/install.sls
+++ b/kubernetes/server/package/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.server.pkg.use_upstream in ('package', 'repo') and grains.os_family|lower in ('redhat', 'debian') %}
 
@@ -15,26 +14,26 @@ include:
         {%- endif %}
         {%- if grains.os != 'Windows' %}
 
-{{ formula }}-server-package-install-deps:
+kubernetes-server-package-install-deps:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
     - require_in:
-      - pkg: {{ formula }}-server-package-install-pkgs
+      - pkg: kubernetes-server-package-install-pkgs
         {%- endif %}
 
-{{ formula }}-server-package-install-pkgs:
+kubernetes-server-package-install-pkgs:
   pkg.installed:
     - names: {{ d.server.pkg.commands|unique|json }}
     - runas: {{ d.identity.rootuser }}
     - reload_modules: true
             {%- if d.server.pkg.use_upstream == 'repo' %}
     - require:
-      - pkgrepo: {{ formula }}-package-repo-managed
+      - pkgrepo: kubernetes-package-repo-managed
             {%- endif %}
 
     {%- else %}
 
-{{ formula }}-server-package-install-other:
+kubernetes-server-package-install-other:
   test.show_notification:
     - text: |
         The server package is unavailable for {{ salt['grains.get']('finger', grains.os_family) }}

--- a/kubernetes/sigs/alternatives/clean.sls
+++ b/kubernetes/sigs/alternatives/clean.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- if 'wanted' in d.sigs and d.sigs.wanted %}
@@ -11,7 +10,7 @@
                 {%- if 'pkg' in d.sigs and tool in d.sigs['pkg'] and d.sigs['pkg'][tool] %}
                     {%- for cmd in d.sigs['pkg'][tool]['commands']|unique %}
 
-{{ formula }}-sigs-{{ tool }}-alternatives-clean-{{ cmd }}:
+kubernetes-sigs-{{ tool }}-alternatives-clean-{{ cmd }}:
   alternatives.remove:
     - name: link-k8s-sigs-{{ tool }}-{{ cmd }}
     - path: {{ d.sigs['pkg'][tool]['path'] }}/{{ cmd }}

--- a/kubernetes/sigs/alternatives/install.sls
+++ b/kubernetes/sigs/alternatives/install.sls
@@ -3,7 +3,6 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if d.linux.altpriority|int > 0 and grains.kernel == 'Linux' and grains.os_family not in ('Arch',) %}
         {%- set sls_archive_install = tplroot ~ '.sigs.archive.install' %}
@@ -18,7 +17,7 @@ include:
                     {%- for cmd in d.sigs.pkg[tool]['commands']|unique %}
 
 
-{{ formula }}-sigs-{{ tool }}-alternatives-install-bin-{{ cmd }}:
+kubernetes-sigs-{{ tool }}-alternatives-install-bin-{{ cmd }}:
                     {%- if grains.os_family not in ('Suse', 'Arch') %}
   alternatives.install:
     - name: link-k8s-sigs-{{ tool }}-{{ cmd }}
@@ -37,9 +36,9 @@ include:
     - require:
       - sls: {{ sls_archive_install if d.sigs.pkg[tool]['use_upstream'] == 'archive' else sls_binary_install }}
     - require_in:
-      - alternatives: {{ formula }}-sigs-{{ tool }}-alternatives-set-bin-{{ cmd }}
+      - alternatives: kubernetes-sigs-{{ tool }}-alternatives-set-bin-{{ cmd }}
 
-{{ formula }}-sigs-{{ tool }}-alternatives-set-bin-{{ cmd }}:
+kubernetes-sigs-{{ tool }}-alternatives-set-bin-{{ cmd }}:
   alternatives.set:
     - unless: {{ grains.os_family in ('Suse', 'Arch') }} || false
     - name: link-k8s-sigs-{{ tool }}-{{ cmd }}

--- a/kubernetes/sigs/archive/clean.sls
+++ b/kubernetes/sigs/archive/clean.sls
@@ -3,13 +3,12 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'wanted' in d.sigs and d.sigs.wanted %}
         {%- for tool in d.sigs.wanted|unique %}
             {%- if 'pkg' in d.sigs and tool in d.sigs['pkg'] and d.sigs['pkg'][tool] %}
 
-{{ formula }}-sigs-archive-{{ tool }}-clean:
+kubernetes-sigs-archive-{{ tool }}-clean:
   file.absent:
     - names:
       - "{{ d.sigs['pkg'][tool]['path'] }}"

--- a/kubernetes/sigs/archive/install.sls
+++ b/kubernetes/sigs/archive/install.sls
@@ -3,12 +3,11 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 {%- from tplroot ~ "/files/macros.jinja" import format_kwargs with context %}
 
     {%- if grains.os|lower != 'windows' %}
 
-{{ formula }}-sigs-archive-deps-install:
+kubernetes-sigs-archive-deps-install:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
 
@@ -19,16 +18,16 @@
                 {%- set p = d.sigs['pkg'][tool] %}
                 {%- if p['use_upstream'] == 'archive' and 'archive' in p %}
 
-{{ formula }}-sigs-archive-{{ tool }}-install:
+kubernetes-sigs-archive-{{ tool }}-install:
   file.directory:
     - name: {{ p['path'] }}
     - clean: {{ d.clean }}
     - makedirs: True
     - require_in:
-      - archive: {{ formula }}-sigs-archive-{{ tool }}-install
+      - archive: kubernetes-sigs-archive-{{ tool }}-install
                     {%- if grains.os|lower != 'windows' %}
     - require:
-      - pkg: {{ formula }}-sigs-archive-deps-install
+      - pkg: kubernetes-sigs-archive-deps-install
     - mode: 755
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
@@ -52,15 +51,15 @@
                         {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                             {%- for cmd in p['commands']|unique %}
 
-{{ formula }}-sigs-archive-{{ tool }}-install-symlink-{{ cmd }}:
+kubernetes-sigs-archive-{{ tool }}-install-symlink-{{ cmd }}:
   file.symlink:
     - name: /usr/local/bin/{{ cmd }}
-    - target: {{ p['path'] }}/bin/{{ tool }}
+    - target: {{ p['path'] }}/bin/{{ cmd }}
     - force: True
     - onlyif:
-      - test -f {{ p['path'] }}/bin/{{ tool }}
+      - test -f {{ p['path'] }}/bin/{{ cmd }}
     - require:
-      - archive: {{ formula }}-sigs-archive-{{ tool }}-install
+      - archive: kubernetes-sigs-archive-{{ tool }}-install
 
                             {%- endfor %}
                         {%- endif %}
@@ -75,7 +74,7 @@
         {%- endfor %}
         {%- if grains.os|lower == 'windows' %}
 
-{{ formula }}-sigs-archive-install-bashrc:
+kubernetes-sigs-archive-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -84,7 +83,7 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-sigs-archive-install-bashrc
+      - file: kubernetes-sigs-archive-install-bashrc
 
         {%- endif %}
     {%- endif %}

--- a/kubernetes/sigs/binary/clean.sls
+++ b/kubernetes/sigs/binary/clean.sls
@@ -3,14 +3,13 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if 'wanted' in d.sigs and d.sigs.wanted %}
         {%- for tool in d.sigs.wanted|unique %}
             {%- if d.sigs.pkg[tool]['use_upstream'] == 'binary' %}
                 {%- if 'pkg' in d.sigs and tool in d.sigs['pkg'] and d.sigs['pkg'][tool] %}
 
-{{ formula }}-sigs-binary-{{ tool }}-clean:
+kubernetes-sigs-binary-{{ tool }}-clean:
   file.absent:
     - names:
       - {{ d.sigs['pkg'][tool]['path'] }}

--- a/kubernetes/sigs/binary/install.sls
+++ b/kubernetes/sigs/binary/install.sls
@@ -3,11 +3,10 @@
 
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import data as d with context %}
-{%- set formula = d.formula %}
 
     {%- if grains.os|lower != 'windows' %}
 
-{{ formula }}-sigs-binary-deps-install:
+kubernetes-sigs-binary-deps-install:
   pkg.installed:
     - names: {{ d.pkg.deps|json }}
 
@@ -18,7 +17,7 @@
                 {%- if d.sigs.pkg[tool]['use_upstream'] == 'binary' and 'binary' in d.sigs.pkg[tool] %}
                     {%- set p = d.sigs['pkg'][tool] %}
 
-{{ formula }}-sigs-binary-{{ tool }}-install:
+kubernetes-sigs-binary-{{ tool }}-install:
   file.managed:
     - name: {{ p['path'] }}{{ tool }}
     - source: {{ p['binary']['source'] }}
@@ -32,22 +31,22 @@
                    {%- if grains.os|lower != 'windows' %}
     - mode: '0755'
     - require:
-      - pkg: {{ formula }}-sigs-binary-deps-install
+      - pkg: kubernetes-sigs-binary-deps-install
     - user: {{ d.identity.rootuser }}
     - group: {{ d.identity.rootgroup }}
 
                        {%- if d.linux.altpriority|int == 0 or grains.os_family in ('Arch', 'MacOS') %}
                            {%- for cmd in p['commands']|unique %}
 
-{{ formula }}-sigs-binary-{{ tool }}-install-symlink-{{ cmd }}:
+kubernetes-sigs-binary-{{ tool }}-install-symlink-{{ cmd }}:
   file.symlink:
     - name: /usr/local/bin/{{ cmd }}
-    - target: {{ p['path'] }}/bin/{{ tool }}
+    - target: {{ p['path'] }}/bin/{{ cmd }}
     - force: True
     - onlyif:
-      - test -f {{ p['path'] }}/bin/{{ tool }}
+      - test -f {{ p['path'] }}/bin/{{ cmd }}
     - require:
-      - file: {{ formula }}-sigs-binary-{{ tool }}-install
+      - file: kubernetes-sigs-binary-{{ tool }}-install
 
                            {%- endfor %}
                        {%- endif %}
@@ -62,7 +61,7 @@
         {%- endfor %}
         {%- if grains.os|lower == 'windows' %}
 
-{{ formula }}-sigs-binary-install-bashrc:
+kubernetes-sigs-binary-install-bashrc:
   file.replace:
     - name: C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - pattern: '^export PATH=${PATH}:/cygdrive/c/kubernetes/bin$'
@@ -71,7 +70,7 @@
   cmd.run:
     - name: sed -i -e "s/\r//g" C:\cygwin64\home\{{ d.identity.rootuser }}\.bashrc
     - onchanges:
-      - file: {{ formula }}-sigs-binary-install-bashrc
+      - file: kubernetes-sigs-binary-install-bashrc
 
         {%- endif %}
     {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -15,6 +15,7 @@ kubernetes:
     - devlibs
     - devtools
     - sigs
+    - crimgr
   sigs:
     wanted:
       - kind

--- a/test/integration/arch/controls/default_spec.rb
+++ b/test/integration/arch/controls/default_spec.rb
@@ -98,6 +98,14 @@ control 'kubernetes archive' do
     # it { should be_symlink }
     it { should_not be_directory }
   end
+  describe file('/opt/intel/bin/cri-resmgr') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+  describe file('/usr/local/bin/cri-resmgr') do
+    # it { should be_symlink }
+    it { should_not be_directory }
+  end
   describe file('/usr/local/k8s-devtools-stern-1.11.0/bin/stern') do
     it { should exist }
     its('mode') { should cmp '0755' }

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -98,6 +98,14 @@ control 'kubernetes archive' do
     it { should be_symlink }
     it { should_not be_directory }
   end
+    describe file('/opt/intel/bin/cri-resmgr') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+  describe file('/usr/local/bin/cri-resmgr') do
+    # it { should be_symlink }
+    it { should_not be_directory }
+  end
   describe file('/usr/local/k8s-devtools-stern-1.11.0/bin/stern') do
     it { should exist }
     its('mode') { should cmp '0755' }

--- a/test/integration/redhat/controls/default_spec.rb
+++ b/test/integration/redhat/controls/default_spec.rb
@@ -98,6 +98,14 @@ control 'kubernetes archive' do
     it { should be_symlink }
     it { should_not be_directory }
   end
+    describe file('/opt/intel/bin/cri-resmgr') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+  describe file('/usr/local/bin/cri-resmgr') do
+    # it { should be_symlink }
+    it { should_not be_directory }
+  end
   describe file('/usr/local/k8s-devtools-stern-1.11.0/bin/stern') do
     it { should exist }
     its('mode') { should cmp '0755' }

--- a/test/salt/pillar/redhat.sls
+++ b/test/salt/pillar/redhat.sls
@@ -14,6 +14,7 @@ kubernetes:
     - devlibs
     - devtools
     - sigs
+    - crimgr
   sigs:
     wanted:
       - kind


### PR DESCRIPTION

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [x] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This PR adds basic cri-resource-manager support and removes some excessive jinja

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
          ID: kubernetes-cri-resource-manager-archive-install
    Function: file.directory
        Name: /usr/local/k8s-crimgr-0.4.1/
      Result: True
     Comment: Directory /usr/local/k8s-crimgr-0.4.1 updated
     Started: 02:46:18.591823
    Duration: 68.142 ms
     Changes:
              ----------
              /usr/local/k8s-crimgr-0.4.1:
                  New Dir
----------
          ID: kubernetes-cri-resource-manager-archive-install
    Function: archive.extracted
        Name: /usr/local/k8s-crimgr-0.4.1/
      Result: True
     Comment: https://github.com/intel/cri-resource-manager/releases/download/v0.4.1/cri-resource-manager-0.4.1.x86_64.tar.gz extracted to /usr/local/k8s-crim
gr-0.4.1/, due to absence of one or more files/dirs. Output was trimmed to 100 number of lines
     Started: 02:46:18.660944
    Duration: 4741.783 ms
     Changes:
              ----------
              extracted_files:
                  - ./etc/systemd/system/
                  - ./etc/systemd/system/cri-resource-manager.service
                  - ./etc/cri-resmgr/fallback.cfg.sample
                  - ./etc/default/cri-resource-manager
                  - ./opt/intel/bin/
                  - ./opt/intel/bin/cri-resmgr
                  - ./opt/intel/share/
                  - ./opt/intel/share/doc/
                  - ./opt/intel/share/doc/cri-resource-manager/
                  - ./opt/intel/share/doc/cri-resource-manager/security.md
                  - ./opt/intel/share/doc/cri-resource-manager/LICENSE
              updated ownership:
                  True
----------
          ID: kubernetes-cri-resource-manager-archive-install-symlink-cri-resmgr
    Function: file.symlink
        Name: /usr/local/bin/cri-resmgr
      Result: True
     Comment: Created new symlink /usr/local/bin/cri-resmgr -> /usr/local/k8s-crimgr-0.4.1//bin/cri-resmgr
     Started: 02:46:23.402998
    Duration: 10467.605 ms
     Changes:
              ----------
              new:
                  /usr/local/bin/cri-resmgr

Summary for local
------------
Succeeded: 3 (changed=3)
Failed:    0

```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


